### PR TITLE
Make stacks updateable

### DIFF
--- a/hot/dockerhost-stack-1.yaml
+++ b/hot/dockerhost-stack-1.yaml
@@ -38,14 +38,9 @@ resources:
         - port: { get_resource: my_dockerhost_management_port }
       block_device_mapping_v2:
         - device_name: vda
-          volume_id: { get_resource: my_dockerhost_boot_volume }
+          image: { get_param: image }
+          volume_size: { get_param: boot_volume_size }
       config_drive: { get_param: config_drive }
-
-  my_dockerhost_boot_volume:
-    type: "OS::Cinder::Volume"
-    properties:
-      image: { get_param: image }
-      size: { get_param: boot_volume_size }
 
   my_dockerhost_management_port:
     type: "OS::Neutron::Port"

--- a/hot/dockerhost-stack-1.yaml
+++ b/hot/dockerhost-stack-1.yaml
@@ -38,6 +38,7 @@ resources:
         - port: { get_resource: my_dockerhost_management_port }
       block_device_mapping_v2:
         - device_name: vda
+          delete_on_termination: true
           image: { get_param: image }
           volume_size: { get_param: boot_volume_size }
       config_drive: { get_param: config_drive }

--- a/hot/dockerhost-stack-2.yaml
+++ b/hot/dockerhost-stack-2.yaml
@@ -38,14 +38,9 @@ resources:
         - port: { get_resource: my_dockerhost_management_port }
       block_device_mapping_v2:
         - device_name: vda
-          volume_id: { get_resource: my_dockerhost_boot_volume }
+          image: { get_param: image }
+          volume_size: { get_param: boot_volume_size }
       config_drive: { get_param: config_drive }
-
-  my_dockerhost_boot_volume:
-    type: "OS::Cinder::Volume"
-    properties:
-      image: { get_param: image }
-      size: { get_param: boot_volume_size }
 
   my_dockerhost_management_port:
     type: "OS::Neutron::Port"

--- a/hot/dockerhost-stack-2.yaml
+++ b/hot/dockerhost-stack-2.yaml
@@ -38,6 +38,7 @@ resources:
         - port: { get_resource: my_dockerhost_management_port }
       block_device_mapping_v2:
         - device_name: vda
+          delete_on_termination: true
           image: { get_param: image }
           volume_size: { get_param: boot_volume_size }
       config_drive: { get_param: config_drive }

--- a/hot/dockerhost-stack-3.yaml
+++ b/hot/dockerhost-stack-3.yaml
@@ -45,6 +45,18 @@ resources:
       user_data: { get_resource: my_config }
       user_data_format: RAW
 
+  my_docker_volume:
+    type: "OS::Cinder::Volume"
+    properties:
+      size: 5
+      name: docker-volume
+
+  my_docker_volume_attachment:
+    type: "OS::Cinder::VolumeAttachment"
+    properties:
+      instance_uuid: { get_resource: my_dockerhost }
+      volume_id: { get_resource: my_docker_volume }
+
   my_dockerhost_management_port:
     type: "OS::Neutron::Port"
     properties:
@@ -114,6 +126,13 @@ resources:
     type: "OS::Heat::CloudConfig"
     properties:
       cloud_config:
+        device_aliases:
+          docker: '/dev/vdb'
+        fs_setup:
+          - filesystem: btrfs
+            device: docker
+        mounts:
+          - [ 'docker', '/var/lib/docker' ]
         package_update: true
         package_upgrade: true
 

--- a/hot/dockerhost-stack-3.yaml
+++ b/hot/dockerhost-stack-3.yaml
@@ -38,6 +38,7 @@ resources:
         - port: { get_resource: my_dockerhost_management_port }
       block_device_mapping_v2:
         - device_name: vda
+          delete_on_termination: true
           image: { get_param: image }
           volume_size: { get_param: boot_volume_size }
       config_drive: { get_param: config_drive }

--- a/hot/dockerhost-stack-3.yaml
+++ b/hot/dockerhost-stack-3.yaml
@@ -38,16 +38,11 @@ resources:
         - port: { get_resource: my_dockerhost_management_port }
       block_device_mapping_v2:
         - device_name: vda
-          volume_id: { get_resource: my_dockerhost_boot_volume }
+          image: { get_param: image }
+          volume_size: { get_param: boot_volume_size }
       config_drive: { get_param: config_drive }
       user_data: { get_resource: my_config }
       user_data_format: RAW
-
-  my_dockerhost_boot_volume:
-    type: "OS::Cinder::Volume"
-    properties:
-      image: { get_param: image }
-      size: { get_param: boot_volume_size }
 
   my_dockerhost_management_port:
     type: "OS::Neutron::Port"

--- a/hot/dockerhost-stack.yaml
+++ b/hot/dockerhost-stack.yaml
@@ -122,6 +122,16 @@ resources:
       - my_router_interface
       - my_router_gateway
 
+  all_done_handle:
+    type: OS::Heat::WaitConditionHandle
+
+  all_done:
+    type: OS::Heat::WaitCondition
+    properties:
+      handle: {get_resource: all_done_handle}
+      count: 1
+      timeout: 600
+
   my_config:
     type: "OS::Heat::CloudConfig"
     properties:
@@ -148,6 +158,8 @@ resources:
           - docker-compose-plugin
         groups:
           - docker
+        runcmd:
+          - { get_attr: ['all_done_handle', 'curl_cli'] }
         system_info:
           default_user:
             groups: [docker]

--- a/hot/dockerhost-stack.yaml
+++ b/hot/dockerhost-stack.yaml
@@ -45,6 +45,18 @@ resources:
       user_data: { get_resource: my_config }
       user_data_format: RAW
 
+  my_docker_volume:
+    type: "OS::Cinder::Volume"
+    properties:
+      size: 5
+      name: docker-volume
+
+  my_docker_volume_attachment:
+    type: "OS::Cinder::VolumeAttachment"
+    properties:
+      instance_uuid: { get_resource: my_dockerhost }
+      volume_id: { get_resource: my_docker_volume }
+
   my_dockerhost_management_port:
     type: "OS::Neutron::Port"
     properties:
@@ -119,6 +131,13 @@ resources:
             docker.list:
               source: deb [arch=amd64] https://download.docker.com/linux/ubuntu $RELEASE stable
               keyid: 9DC858229FC7DD38854AE2D88D81803C0EBFCD88
+        device_aliases:
+          docker: '/dev/vdb'
+        fs_setup:
+          - filesystem: btrfs
+            device: docker
+        mounts:
+          - [ 'docker', '/var/lib/docker' ]
         package_update: true
         package_upgrade: true
         packages:

--- a/hot/dockerhost-stack.yaml
+++ b/hot/dockerhost-stack.yaml
@@ -38,6 +38,7 @@ resources:
         - port: { get_resource: my_dockerhost_management_port }
       block_device_mapping_v2:
         - device_name: vda
+          delete_on_termination: true
           image: { get_param: image }
           volume_size: { get_param: boot_volume_size }
       config_drive: { get_param: config_drive }

--- a/hot/dockerhost-stack.yaml
+++ b/hot/dockerhost-stack.yaml
@@ -38,16 +38,11 @@ resources:
         - port: { get_resource: my_dockerhost_management_port }
       block_device_mapping_v2:
         - device_name: vda
-          volume_id: { get_resource: my_dockerhost_boot_volume }
+          image: { get_param: image }
+          volume_size: { get_param: boot_volume_size }
       config_drive: { get_param: config_drive }
       user_data: { get_resource: my_config }
       user_data_format: RAW
-
-  my_dockerhost_boot_volume:
-    type: "OS::Cinder::Volume"
-    properties:
-      image: { get_param: image }
-      size: { get_param: boot_volume_size }
 
   my_dockerhost_management_port:
     type: "OS::Neutron::Port"


### PR DESCRIPTION
When we configure servers (via `OS::Nova::Server`) for boot-from-volume, and we actually want to use a single persistent volume to boot from, then this creates a catch-22 when we update the server resource in such a way that Heat detects that the server requires replacement: Heat then tries to spin up a new server before removing the old one, but at that stage it obviously cannot attach the boot volume.

One way in which we can circumvent this problem is to use BFV, but to not actually boot from a single boot volume, but rather to recreate the boot volume each time the server is recreated.

Thus:

* Drop the `my_dockerhost_boot_volume` resource.
* Instead, create the boot volume directly from the `block_device_mapping_v2` map in the `OS::Nova::Server` resource.

We still need a _separate_ volume — not for booting the host, but for Docker to actually manage containers on. For that, however, we can't use `block_device_mapping_v2`; we must use an `OS::Cinder::Volume` resource instead.

Finally, while we're at it, we can add a `WaitCondition` resource to indicate when the entire configuration of the stack (including that of the Docker host) is complete.
