### PR TITLE
fix: Drop unneeded parameter definition

### DIFF
--- a/hot/dockerhost-stack-1.yaml
+++ b/hot/dockerhost-stack-1.yaml
@@ -17,10 +17,6 @@ parameters:
     type: string
     description: Keypair to inject into server
     default: ''
-  public_net:
-    type: string
-    description: Public network name
-    default: ext-net
   config_drive:
     type: boolean
     description: Use config_drive for metadata discovery


### PR DESCRIPTION
In template dockerhost-stack-1.yaml we do not yet bother with a public network, so we drop the definition of public_net parameter.